### PR TITLE
Fix Arbitrary instance for Image PixelRGBA8

### DIFF
--- a/src/Images.hs
+++ b/src/Images.hs
@@ -52,8 +52,8 @@ instance Show (Image PixelCMYK16) where
 instance Arbitrary (Image PixelRGB8) where
    arbitrary = do
        l <- listOf (arbitrary :: Gen Word8)
-       w <- (arbitrary :: Gen Int)
-       h <- (arbitrary :: Gen Int)
+       Positive w <- (arbitrary :: Gen (Positive Int))
+       Positive h <- (arbitrary :: Gen (Positive Int))
        return $ Image { imageWidth = w, imageHeight = h, imageData = VS.fromList l }
 
 instance Show (Image PixelRGB8) where

--- a/src/Images.hs
+++ b/src/Images.hs
@@ -68,14 +68,36 @@ instance Arbitrary (Image Pixel8) where
 
 instance Show (Image Pixel8) where
    show x = ""
- 
- 
+
 instance Arbitrary (Image PixelRGBA8) where
-   arbitrary = do
-       l <- listOf (arbitrary :: Gen Word8)
-       w <- (arbitrary :: Gen Int)
-       h <- (arbitrary :: Gen Int)
-       return $ Image { imageWidth = w, imageHeight = h, imageData = VS.fromList l }
+  arbitrary = do
+    Positive size <- arbitrary :: Gen (Positive Int)
+    pixs          <- listOfSize size
+    Positive w    <- arbitrary :: Gen (Positive Int)
+    let w' = w `rem` size-1
+    return Image { imageWidth  = w'
+                 , imageHeight = w' `div` size-1
+                 , imageData   = VS.fromList pixs
+                 }
+
+listOfSize :: Int → Gen [Word8]
+listOfSize x = fmap concat $ replicateM x genPixel
+
+genPixel :: Gen [Word8]
+genPixel = do
+     a <- arbitrary :: Gen Word8
+     b <- arbitrary :: Gen Word8
+     c <- arbitrary :: Gen Word8
+     d <- arbitrary :: Gen Word8
+     return [a,b,c,d]
+
+instance Arbitrary PixelRGBA8 where
+  arbitrary = do
+    r <- arbitrary :: Gen Word8
+    g <- arbitrary :: Gen Word8
+    b <- arbitrary :: Gen Word8
+    a <- arbitrary :: Gen Word8
+    return $ PixelRGBA8 r g b a
 
 instance Show (Image PixelRGBA8) where
    show x = ""


### PR DESCRIPTION
Modify the Arbitrary instance declaration for `Image PixelRGBA` to resolve #12 . I realized this was a problem when my QuickCheck test kept breaking with an `OutOfBounds` exception; with this, I am able to successfully run the test (though I'm discarding the case when the size of the image is 0 in both dimensions). So I suppose this will fix it for you too.
