### PR TITLE
Adapt to template-haskell-2.11 changes (Kind filed in constructors)

### DIFF
--- a/src/DeriveArbitrary.hs
+++ b/src/DeriveArbitrary.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE CPP #-}
 module DeriveArbitrary (
 --    module Megadeth.Prim,
 --    module Megadeth.DeriveArbitrary,
@@ -36,6 +37,12 @@ import Control.Monad
 import Control.Arrow
 import Control.Applicative
 import Data.List
+
+#if MIN_VERSION_template_haskell(2,11,0)
+#    define TH211MBKIND _maybe_kind
+#else
+#    define TH211MBKIND
+#endif
 
 -- | Build the arbitrary function with makeArbs
 chooseExpQ :: Name -> Name -> Name -> Integer -> Type -> ExpQ
@@ -78,7 +85,7 @@ deriveArbitrary t = do
     inf <- reify t
     runIO $ print $ "Deriving:" ++ show inf
     case inf of
-        TyConI (DataD _ _ params constructors _) -> do
+        TyConI (DataD _ _ params TH211MBKIND constructors _) -> do
               let ns  = map varT $ paramNames params
                   scons = map (simpleConView t) constructors
                   fcs = filter ((==0) . bf) scons
@@ -109,7 +116,7 @@ deriveArbitrary t = do
                 [d| instance Arbitrary $(applyTo (conT t) ns) where
                                arbitrary = sized go
                                  where go n = $(gos 'go 'n)|]
-        TyConI (NewtypeD _ _ params con _) -> do 
+        TyConI (NewtypeD _ _ params TH211MBKIND con _) -> do
             let ns = map varT $ paramNames params
                 scon = simpleConView t con
             if not $ null ns then
@@ -279,7 +286,7 @@ customG name = do
                 ConT n -> return $ Left $ "Already derived?" ++ show n
                 d -> return $ Left $ "Not ready for " ++ show d
                 
-        TyConI (DataD _ _ params constructors _) ->
+        TyConI (DataD _ _ params TH211MBKIND constructors _) ->
             let fnm = mkName "prob_gen" -- "customGen_" ++ (map (\x -> if x == '.' then '_' else
                                                                 --x) $ showName name)
                 ns = map varT $ paramNames params

--- a/src/DeriveMutation.hs
+++ b/src/DeriveMutation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns#-}
 {-# LANGUAGE FlexibleInstances,UndecidableInstances#-}
+{-# LANGUAGE CPP #-}
 module DeriveMutation where
 
 import Language.Haskell.TH
@@ -15,6 +16,13 @@ import Control.Applicative
 import Data.List
 
 import Megadeth.Prim
+
+#if MIN_VERSION_template_haskell(2,11,0)
+#    define TH211MBKIND _maybe_kind
+#else
+#    define TH211MBKIND
+#endif
+
 --import Mutation
 --
 -- | Mutation Class
@@ -98,7 +106,7 @@ devMutation name customGen = do
     def <- reify name
     case def of -- We need constructors...
         TyConI (TySynD _ _ ty) -> return [] -- devMutation (headOf ty) Nothing
-        TyConI (DataD _ _ params constructors _) -> do
+        TyConI (DataD _ _ params TH211MBKIND constructors _) -> do
             let fnm = mkName $ "mutt" -- ++ (showName name) 
             let f = funD fnm $ foldl (\ p c ->
                      let 


### PR DESCRIPTION
ghc-8's template-haskell-2.11 added support for
Kind polymorphism. That led to addition of Kind
field in constructor which causes build failures:

  src/DeriveArbitrary.hs:81:17: error:
    • The constructor ‘DataD’ should have 6 arguments, but has been given 5
    • In the pattern: DataD _ _ params constructors _
      In the pattern: TyConI (DataD _ _ params constructors _)

Change introduces CPP macro to get support for
both ghc-7.10 and and ghc-8.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
