### PR TITLE
src/DeriveArbitrary.hs: tweak for ghc-8

### DIFF
--- a/src/DeriveArbitrary.hs
+++ b/src/DeriveArbitrary.hs
@@ -25,7 +25,7 @@ import Data.List.Split
 import Data.Maybe
 -- Gen
 import Language.Haskell.TH
-import Language.Haskell.TH.Syntax
+import Language.Haskell.TH.Syntax as TH
 import Test.QuickCheck
 import GHC.Exts
 import GHC.Types
@@ -43,7 +43,7 @@ import Data.List
 #endif
 
 -- | Build the arbitrary function with makeArbs
-chooseExpQ :: Name -> Name -> Name -> Integer -> Type -> ExpQ
+chooseExpQ :: Name -> Name -> Name -> Integer -> TH.Type -> ExpQ
 chooseExpQ g n t bf (AppT ListT ty) = [| listOf $ resize ($(varE  n) `div` 10) arbitrary |]
 chooseExpQ g n t bf ty | headOf ty /= t = [| resize (max 0 ($(varE n) - 1)) arbitrary |]
 chooseExpQ g n t bf ty =


### PR DESCRIPTION
ghc-8 now exposes 'Types' type which collides
with 'Language.Haskell.TH.Syntax.Type':

```
  [ 16 of 134] Compiling DeriveArbitrary  ( src/DeriveArbitrary.hs, dist/build/QuickFuzz/QuickFuzz-tmp/DeriveArbitrary.dyn_o )

  src/DeriveArbitrary.hs:46:50: error:
    Ambiguous occurrence ‘Type’
    It could refer to either ‘Language.Haskell.TH.Syntax.Type’,
                             imported from ‘Language.Haskell.TH.Syntax’ at src/DeriveArbitrary.hs:28:1-33
                          or ‘GHC.Types.Type’,
                             imported from ‘GHC.Types’ at src/DeriveArbitrary.hs:31:1-16
```

Change uses qualified name from template-haskell package.

Signed-off-by: Sergei Trofimovich siarheit@google.com
