### PR TITLE
Fix build with doc flag

### DIFF
--- a/QuickFuzz.cabal
+++ b/QuickFuzz.cabal
@@ -116,7 +116,7 @@ library
             Test.QuickFuzz.Gen.Document.Xml
 
         build-depends:
-            blaze-html, blaze-markup, easyrender, HaXml, xmlgen, blaze-builder, language-css
+            blaze-html, blaze-markup, easyrender, HaXml, xmlgen, blaze-builder, language-css, pretty
 
     if flag(code) || flag(all)
         cpp-options: -DCODE


### PR DESCRIPTION
Passing --flag QuickFuzz:doc is currently broken and complains about missing `pretty`. This patch fixes the issue.