### PR TITLE
Fix typo

### DIFF
--- a/QuickFuzz.cabal
+++ b/QuickFuzz.cabal
@@ -53,7 +53,7 @@ flag net
   Manual:      True
 
 flag bnfc
-  Description: Supports bnfc grammer formats.
+  Description: Supports bnfc grammar formats.
   Default:     False
   Manual:      True
 


### PR DESCRIPTION
Fix typo in flag description (grammer -> grammar).